### PR TITLE
Re-route HTML5 validator requests to Nu Checker.

### DIFF
--- a/httpd/cgi-bin/check
+++ b/httpd/cgi-bin/check
@@ -1097,6 +1097,45 @@ sub html5_validate (\$)
         $req->header('Accept-Encoding', 'identity');
     }
 
+    if ($File->{'Direct Input'}) {
+        print "Content-type: text/html\n\n";
+        print "<!doctype html>";
+        print "<style>.hide { display: none }</style>";
+        print "<script>setTimeout('document.vnupost.submit()',0)</script>";
+        print "<form name=vnupost method=post enctype=multipart/form-data action=https://validator.w3.org/nu/>";
+        # for direct input, must always send vnu the showsource=yes option
+        print "<input type=hidden name=showsource value=yes>";
+        if ($File->{Opt}->{Outline}) {
+            print "<input type=hidden name=showoutline value=yes>";
+        }
+        if ($File->{Opt}->{Output} eq 'json') {
+            print "<input type=hidden name=out value=json>";
+        }
+        print "<textarea id=doc name=content>";
+        print $req->content;
+        print "</textarea>";
+        print "<input type=submit>";
+        print "</form>";
+        print "<script>document.vnupost.className = 'hide'</script>";
+        exit;
+    } elsif (!$File->{'Is Upload'}) {
+        my $uri = $File->{'URI'};
+        my $source_option = "";
+        my $outline_option = "";
+        my $output_option = "";
+        if ($File->{Opt}->{'Show Source'}) {
+            $source_option = "&showsource=yes";
+        }
+        if ($File->{Opt}->{Outline}) {
+            $outline_option = "&showoutline=yes";
+        }
+        if ($File->{Opt}->{Output} eq 'json') {
+            $output_option = "&out=json";
+        }
+        print redirect
+            'https://validator.w3.org/nu/?doc=' . uri_escape($uri) .
+            $source_option . $outline_option . $output_option;
+    }
     my $res = $ua->request($req);
     if (!$res->is_success()) {
         $File->{'Error Flagged'} = TRUE;


### PR DESCRIPTION
This is a simple but powerful change to the markup-validator code to ease
migration of users to the Nu Html Checker. You can try the outcomes of the
change at http://qa-dev.w3.org/wmvs/mike/

The change has the following specific effects on the behavior of the validator.

1. "Validate by URI": if a document either has an HTML5 `<!doctype html>`
   doctype, or if a user manually selects the HTML5-checking option, the
   request is automatically run directly through https://validator.w3.org/nu.

   That is, the validation results will be shown directly from the
   http://validator.w3.org/nu Web UI, rather then being passed back to
   http://validator.w3.org for post-processing and display.

2. "Validate by Direct Input": Same as above; if the text entered into the
   input areaa has a <!doctype html> doctype or a user manually selects the
   HTML5-checking option, results are shown by http://validator.w3.org/nu

3. "Validate by File Upload". No change. (It's not possible to
   automatically redirect file-upload requests to the Nu Html Checker in
   the way we can for "Validate by URI" and "Validate by Direct Input".