### PR TITLE
gzip-decode HTML5 direct input before sending

### DIFF
--- a/httpd/cgi-bin/check
+++ b/httpd/cgi-bin/check
@@ -1098,6 +1098,8 @@ sub html5_validate (\$)
     }
 
     if ($File->{'Direct Input'}) {
+        # if $req isn't actually encoded, this decode() call does nothing
+        $req->decode("gzip");
         print "Content-type: text/html\n\n";
         print "<!doctype html>";
         print "<style>.hide { display: none }</style>";


### PR DESCRIPTION
If the direct input we’re sending on hasn’t actually already been gzip-encoded,
the `decode()` call we make here is just a no-op.