### PR TITLE
Use data-URI+redirect to check HTML5 direct input.

### DIFF
--- a/httpd/cgi-bin/check
+++ b/httpd/cgi-bin/check
@@ -28,6 +28,7 @@ use 5.008;
 use strict;
 use warnings;
 use utf8;
+use MIME::Base64 ();
 
 package W3C::Validator::MarkupValidator;
 
@@ -1097,45 +1098,19 @@ sub html5_validate (\$)
         $req->header('Accept-Encoding', 'identity');
     }
 
+    my $source_option = $File->{Opt}->{'Show Source'} ? "&showsource=yes" : "";
+    my $outline_option = $File->{Opt}->{Outline} ? "&showoutline=yes" : "";
+    my $output_option = $File->{Opt}->{Output} eq 'json' ? "&out=json" : "";
+    my $uri = uri_escape($File->{'URI'});
     if ($File->{'Direct Input'}) {
         # if $req isn't actually encoded, this decode() call does nothing
         $req->decode("gzip");
-        print "Content-type: text/html\n\n";
-        print "<!doctype html>";
-        print "<style>.hide { display: none }</style>";
-        print "<script>setTimeout('document.vnupost.submit()',0)</script>";
-        print "<form name=vnupost method=post enctype=multipart/form-data action=https://validator.w3.org/nu/>";
-        # for direct input, must always send vnu the showsource=yes option
-        print "<input type=hidden name=showsource value=yes>";
-        if ($File->{Opt}->{Outline}) {
-            print "<input type=hidden name=showoutline value=yes>";
-        }
-        if ($File->{Opt}->{Output} eq 'json') {
-            print "<input type=hidden name=out value=json>";
-        }
-        print "<textarea id=doc name=content>";
-        print $req->content;
-        print "</textarea>";
-        print "<input type=submit>";
-        print "</form>";
-        print "<script>document.vnupost.className = 'hide'</script>";
-        exit;
-    } elsif (!$File->{'Is Upload'}) {
-        my $uri = $File->{'URI'};
-        my $source_option = "";
-        my $outline_option = "";
-        my $output_option = "";
-        if ($File->{Opt}->{'Show Source'}) {
-            $source_option = "&showsource=yes";
-        }
-        if ($File->{Opt}->{Outline}) {
-            $outline_option = "&showoutline=yes";
-        }
-        if ($File->{Opt}->{Output} eq 'json') {
-            $output_option = "&out=json";
-        }
+        $uri = "data:text/html;charset=utf-8;base64," .
+            uri_escape(MIME::Base64::encode_base64($req->content));
+    }
+    if (!$File->{'Is Upload'}) {
         print redirect
-            'https://validator.w3.org/nu/?doc=' . uri_escape($uri) .
+            'https://validator.w3.org/nu/?doc=' . $uri .
             $source_option . $outline_option . $output_option;
     }
     my $res = $ua->request($req);


### PR DESCRIPTION
This replaces the different approach we took in PR #1 for re-routing
checking of HTML5 documents submitted by direct input.

Tested and found to work as expected.