### PR TITLE
add cookies handler

### DIFF
--- a/httpd/cgi-bin/check
+++ b/httpd/cgi-bin/check
@@ -50,6 +50,7 @@ use Encode::Alias qw();
 use Encode::HanExtra qw();        # for some chinese character encodings,
                                   # e.g gb18030
 use File::Spec::Functions qw(catfile rel2abs tmpdir);
+use HTTP::Cookies qw();
 use HTML::Encoding 0.52 qw();
 use HTML::HeadParser 3.60 qw();    # Needed for HTML5 meta charset workaround
 use HTML::Parser 3.24 qw();        # Need 3.24 for $p->parse($code_ref)
@@ -859,6 +860,7 @@ sub compoundxml_validate (\$)
 {
     my $File = shift;
     my $ua = W3C::Validator::UserAgent->new($CFG, $File);
+    $ua->cookie_jar({});
 
     push(
         @{$File->{Parsers}},
@@ -1020,6 +1022,7 @@ sub html5_validate (\$)
 {
     my $File = shift;
     my $ua = W3C::Validator::UserAgent->new($CFG, $File);
+    $ua->cookie_jar({});
 
     push(
         @{$File->{Parsers}},
@@ -1744,6 +1747,7 @@ sub handle_uri
     my $File = shift;    # The master datastructure.
 
     my $ua = W3C::Validator::UserAgent->new($CFG, $File);
+    $ua->cookie_jar({});
 
     my $uri = URI->new(ref $q ? $q->param('uri') : $q)->canonical();
     $uri->fragment(undef);


### PR DESCRIPTION
Fix issue with websites that on first user's visit request/redirect to single sign-on service.

Without cookies, websites loop on single sign-on service and can't be checked by validator (too many redirections).
