### PR TITLE
Resolve warnings in check

### DIFF
--- a/httpd/cgi-bin/check
+++ b/httpd/cgi-bin/check
@@ -1746,7 +1746,7 @@ sub handle_uri
 
     my $ua = W3C::Validator::UserAgent->new($CFG, $File);
 
-    my $uri = URI->new(ref $q ? $q->param('uri') : $q)->canonical();
+    my $uri = URI->new(ref $q ? scalar $q->param('uri') : $q)->canonical();
     $uri->fragment(undef);
 
     if (!$uri->scheme()) {
@@ -2759,7 +2759,7 @@ sub prepCGI
         next if ($param eq 'uploaded_file' || $param eq 'fragment');
 
         # Decode all other defined values as UTF-8.
-        my @values = map { Encode::decode_utf8($_) } $q->param($param);
+        my @values = map { Encode::decode_utf8($_) } $q->multi_param($param);
         $q->param($param, @values);
 
         # Skip parameters that should not be treated as booleans.
@@ -3309,22 +3309,22 @@ sub self_url_q
 
     # Pass-through parameters
     for my $param (qw(uri accept accept-language accept-charset)) {
-        $thispage .= "$param=" . uri_escape($q->param($param)) . ';'
+        $thispage .= "$param=" . uri_escape(scalar $q->param($param)) . ';'
             if $q->param($param);
     }
 
     # Boolean parameters
     for my $param (qw(ss outline No200 verbose group)) {
-        $thispage .= "$param=1;" if $q->param($param);
+        $thispage .= "$param=1;" if scalar $q->param($param);
     }
 
     # Others
     if ($q->param('doctype') and $q->param('doctype') !~ /(?:Inline|detect)/i)
     {
-        $thispage .= 'doctype=' . uri_escape($q->param('doctype')) . ';';
+        $thispage .= 'doctype=' . uri_escape(scalar $q->param('doctype')) . ';';
     }
     if ($q->param('charset') and $q->param('charset') !~ /detect/i) {
-        $thispage .= 'charset=' . uri_escape($q->param('charset')) . ';';
+        $thispage .= 'charset=' . uri_escape(scalar $q->param('charset')) . ';';
     }
 
     $thispage =~ s/[\?;]$//;

--- a/httpd/cgi-bin/check
+++ b/httpd/cgi-bin/check
@@ -2778,11 +2778,11 @@ sub prepCGI
 
     # Use "url" unless a "uri" was also given.
     if ($q->param('url') and not $q->param('uri')) {
-        $q->param('uri', $q->param('url'));
+        $q->param('uri', scalar $q->param('url'));
     }
 
     # Set output mode; needed in get_error_template if we end up there.
-    $File->{Opt}->{Output} = $q->param('output') || 'html';
+    $File->{Opt}->{Output} = scalar $q->param('output') || 'html';
 
     # Issue a redirect for uri=referer.
     if ($q->param('uri') and $q->param('uri') eq 'referer') {
@@ -2806,7 +2806,7 @@ sub prepCGI
 
     # Supersede URL with an uploaded file.
     if ($q->param('uploaded_file')) {
-        $q->param('uri', 'upload://' . $q->param('uploaded_file'));
+        $q->param('uri', 'upload://' . scalar $q->param('uploaded_file'));
         $File->{'Is Upload'} = TRUE;    # Tag it for later use.
     }
 

--- a/httpd/cgi-bin/check
+++ b/httpd/cgi-bin/check
@@ -26,7 +26,8 @@ use 5.008;
 #
 # Pragmas.
 use strict;
-use warnings;
+# enable warnings when not using in production
+#use warnings;
 use utf8;
 
 package W3C::Validator::MarkupValidator;


### PR DESCRIPTION
Disable use warnings by default. Developers need to enable it by hand.
Take into account changes in CGI.pm re param() used in list context
