### PR TITLE
Corrected typo in httpd.conf RewriteRule definitions

### DIFF
--- a/httpd/conf/httpd.conf
+++ b/httpd/conf/httpd.conf
@@ -77,8 +77,8 @@ Alias /w3c-validator/   /usr/local/validator/htdocs/
   <IfModule mod_rewrite.c>
     Options +SymLinksIfOwnerMatch
     RewriteBase /w3c-validator/
-    RewriteRule fragment-upload(\.html)? detailed.html    #validate-by-input  [R,L,NE]
-    RewriteRule file-upload(\.html)? detailed.html        #validate-by-upload [R,L,NE]
+    RewriteRule fragment-upload(\.html)?  detailed.html#validate-by-input  [R,L,NE]
+    RewriteRule file-upload(\.html)?      detailed.html#validate-by-upload [R,L,NE]
   </IfModule>
 
   <IfModule mod_expires.c>


### PR DESCRIPTION
Hello,

   was trying to update this project with my Docker based validator image (https://github.com/magnetikonline/dockerhtml5validator) and noted mainline now threw an Apache error.

Tracked it down to 23b23d378870db3246191571a8b4a06db11d6a28 - specifically the two indenting changes made to the `RewriteRule` lines.

This commit corrects that, hopefully the indenting I've provided meets what was envisioned.  

Cheers

   Pete
