### PR TITLE
Use Valid icon files from https://www.w3.org/Icons/ instead of the local copy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Set up Perl
         uses: shogo82148/actions-setup-perl@v1
-      - run: sudo sed -i 's/# deb-src/deb-src/' /etc/apt/sources.list
+      - run: |
+          sudo sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
       - run: sudo apt-get update
       - run: sudo apt-get build-dep --yes w3c-markup-validator
       - run: make && make test

--- a/htdocs/config/types.conf
+++ b/htdocs/config/types.conf
@@ -29,8 +29,6 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html20
     ALT URI   = https://www.w3.org/Icons/valid-html20-blue
-    Local URI = https://www.w3.org/Icons/valid-html20
-    Local ALT URI = https://www.w3.org/Icons/valid-html20-blue
   </Badge>
 </HTML_2_0>
 
@@ -47,8 +45,6 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html20
     ALT URI   = https://www.w3.org/Icons/valid-html20-blue
-    Local URI = https://www.w3.org/Icons/valid-html20
-    Local ALT URI = https://www.w3.org/Icons/valid-html20-blue
   </Badge>
 </HTML_2_0_Level_2>
 
@@ -65,8 +61,6 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html20
     ALT URI   = https://www.w3.org/Icons/valid-html20-blue
-    Local URI = https://www.w3.org/Icons/valid-html20
-    Local ALT URI = https://www.w3.org/Icons/valid-html20-blue
   </Badge>
 </HTML_2_0_Strict>
 
@@ -83,8 +77,6 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html20
     ALT URI   = https://www.w3.org/Icons/valid-html20-blue
-    Local URI = https://www.w3.org/Icons/valid-html20
-    Local ALT URI = https://www.w3.org/Icons/valid-html20-blue
   </Badge>
 </HTML_2_0_Level_1>
 
@@ -101,8 +93,6 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html20
     ALT URI   = https://www.w3.org/Icons/valid-html20-blue
-    Local URI = https://www.w3.org/Icons/valid-html20
-    Local ALT URI = https://www.w3.org/Icons/valid-html20-blue
   </Badge>
 </HTML_2_0_Strict_Level_1>
 
@@ -122,8 +112,6 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html32
     ALT URI   = https://www.w3.org/Icons/valid-html32-blue
-    Local URI = https://www.w3.org/Icons/valid-html32
-    Local ALT URI = https://www.w3.org/Icons/valid-html32-blue
     Height    = 31
     Width     = 88
   </Badge>
@@ -147,8 +135,6 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html40
     ALT URI   = https://www.w3.org/Icons/valid-html40-blue
-    Local URI = https://www.w3.org/Icons/valid-html40
-    Local ALT URI = https://www.w3.org/Icons/valid-html40-blue
     Height    = 31
     Width     = 88
     Alt       = Valid HTML 4.0 Strict
@@ -169,8 +155,6 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html40
     ALT URI   = https://www.w3.org/Icons/valid-html40-blue
-    Local URI = https://www.w3.org/Icons/valid-html40
-    Local ALT URI = https://www.w3.org/Icons/valid-html40-blue
     Height    = 31
     Width     = 88
     Alt       = Valid HTML 4.0 Transitional
@@ -191,8 +175,6 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html40
     ALT URI   = https://www.w3.org/Icons/valid-html40-blue
-    Local URI = https://www.w3.org/Icons/valid-html40
-    Local ALT URI = https://www.w3.org/Icons/valid-html40-blue
     Height    = 31
     Width     = 88
     Alt       = Valid HTML 4.0 Frameset
@@ -213,8 +195,6 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html401
     ALT URI   = https://www.w3.org/Icons/valid-html401-blue
-    Local URI = https://www.w3.org/Icons/valid-html401
-    Local ALT URI = https://www.w3.org/Icons/valid-html401-blue
     Height    = 31
     Width     = 88
     Alt       = Valid HTML 4.01 Strict
@@ -235,8 +215,6 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html401
     ALT URI   = https://www.w3.org/Icons/valid-html401-blue
-    Local URI = https://www.w3.org/Icons/valid-html401
-    Local ALT URI = https://www.w3.org/Icons/valid-html401-blue
     Height    = 31
     Width     = 88
     Alt       = Valid HTML 4.01 Transitional
@@ -257,8 +235,6 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html401
     ALT URI   = https://www.w3.org/Icons/valid-html401-blue
-    Local URI = https://www.w3.org/Icons/valid-html401
-    Local ALT URI = https://www.w3.org/Icons/valid-html401-blue
     Height    = 31
     Width     = 88
     Alt       = Valid HTML 4.01 Frameset
@@ -279,8 +255,6 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html401
     ALT URI   = https://www.w3.org/Icons/valid-html401-blue
-    Local URI = https://www.w3.org/Icons/valid-html401
-    Local ALT URI = https://www.w3.org/Icons/valid-html401-blue
     Height    = 31
     Width     = 88
     Alt       = Valid HTML 4.01 + RDFa 1.1
@@ -302,8 +276,6 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html401
     ALT URI   = https://www.w3.org/Icons/valid-html401-blue
-    Local URI = https://www.w3.org/Icons/valid-html401
-    Local ALT URI = https://www.w3.org/Icons/valid-html401-blue
     Height    = 31
     Width     = 88
     Alt       = Valid HTML 4.01 + ARIA 1.0
@@ -341,8 +313,6 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-xhtml10
     ALT URI   = https://www.w3.org/Icons/valid-xhtml10-blue
-    Local URI = https://www.w3.org/Icons/valid-xhtml10
-    Local ALT URI = https://www.w3.org/Icons/valid-xhtml10-blue
     Height    = 31
     Width     = 88
     Alt       = Valid XHTML 1.0 Strict
@@ -366,8 +336,6 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-xhtml10
     ALT URI   = https://www.w3.org/Icons/valid-xhtml10-blue
-    Local URI = https://www.w3.org/Icons/valid-xhtml10
-    Local ALT URI = https://www.w3.org/Icons/valid-xhtml10-blue
     Height    = 31
     Width     = 88
     Alt       = Valid XHTML 1.0 Transitional
@@ -391,8 +359,6 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-xhtml10
     ALT URI   = https://www.w3.org/Icons/valid-xhtml10-blue
-    Local URI = https://www.w3.org/Icons/valid-xhtml10
-    Local ALT URI = https://www.w3.org/Icons/valid-xhtml10-blue
     Height    = 31
     Width     = 88
     Alt       = Valid XHTML 1.0 Frameset
@@ -417,8 +383,6 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-xhtmlbasic10
     ALT URI   = https://www.w3.org/Icons/valid-xhtmlbasic10-blue
-    Local URI = https://www.w3.org/Icons/valid-xhtmlbasic10
-    Local ALT URI = https://www.w3.org/Icons/valid-xhtmlbasic10-blue
     Height    = 31
     Width     = 88
     Alt       = Valid XHTML Basic 1.0
@@ -509,8 +473,6 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-xhtmlprint10
     ALT URI   = https://www.w3.org/Icons/valid-xhtmlprint10-blue
-    Local URI = https://www.w3.org/Icons/valid-xhtmlprint10
-    Local ALT URI = https://www.w3.org/Icons/valid-xhtmlprint10-blue
     Height    = 31
     Width     = 88
     Alt       = Valid XHTML-Print 1.0
@@ -534,8 +496,6 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-xhtml11
     ALT URI   = https://www.w3.org/Icons/valid-xhtml11-blue
-    Local URI = https://www.w3.org/Icons/valid-xhtml11
-    Local ALT URI = https://www.w3.org/Icons/valid-xhtml11-blue
     Height    = 31
     Width     = 88
     Alt       = Valid XHTML 1.1
@@ -567,7 +527,6 @@
   </Types>
   <Badge>
     URI       = https://validator.w3.org/images/v15445
-    Local URI = images/v15445
     Alt       = Valid ISO/IEC 15445:2000
   </Badge>
 </ISO_IEC_15445_2000>
@@ -584,7 +543,6 @@
   </Types>
   <Badge>
     URI       = https://validator.w3.org/images/v15445
-    Local URI = images/v15445
     Alt       = Valid ISO/IEC 15445:2000
   </Badge>
 </ISO_IEC_15445_2000_MARKUP>
@@ -608,8 +566,6 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-mathml20
     ALT URI   = https://www.w3.org/Icons/valid-mathml20-blue
-    Local URI = https://www.w3.org/Icons/valid-mathml20
-    Local ALT URI = https://www.w3.org/Icons/valid-mathml20-blue
     Height    = 31
     Width     = 88
     Alt       = Valid MathML 2.0
@@ -681,8 +637,6 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-xhtml-rdfa
     ALT URI   = https://www.w3.org/Icons/valid-xhtml-rdfa-blue
-    Local URI = https://www.w3.org/Icons/valid-xhtml-rdfa
-    Local ALT URI = https://www.w3.org/Icons/valid-xhtml-rdfa-blue
     Height    = 31
     Width     = 88
     Alt       = Valid XHTML + RDFa
@@ -706,8 +660,6 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-xhtml11
     ALT URI   = https://www.w3.org/Icons/valid-xhtml11-blue
-    Local URI = https://www.w3.org/Icons/valid-xhtml11
-    Local ALT URI = https://www.w3.org/Icons/valid-xhtml11-blue
     Height    = 31
     Width     = 88
     Alt       = Valid XHTML + ARIA 1.0
@@ -735,8 +687,6 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-svg10
     ALT URI   = https://www.w3.org/Icons/valid-svg10-blue
-    Local URI = https://www.w3.org/Icons/valid-svg10
-    Local ALT URI = https://www.w3.org/Icons/valid-svg10-blue
     Height    = 31
     Width     = 88
     Alt       = Valid SVG 1.0
@@ -760,8 +710,6 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-svg11
     ALT URI   = https://www.w3.org/Icons/valid-svg11-blue
-    Local URI = https://www.w3.org/Icons/valid-svg11
-    Local ALT URI = https://www.w3.org/Icons/valid-svg11-blue
     Height    = 31
     Width     = 88
     Alt       = Valid SVG 1.1
@@ -787,8 +735,6 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-svgtiny11
     ALT URI   = https://www.w3.org/Icons/valid-svgtiny11-blue
-    Local URI = https://www.w3.org/Icons/valid-svgtiny11
-    Local ALT URI = https://www.w3.org/Icons/valid-svgtiny11-blue
     Height    = 31
     Width     = 88
     Alt       = Valid SVG 1.1 Tiny

--- a/htdocs/config/types.conf
+++ b/htdocs/config/types.conf
@@ -29,8 +29,8 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html20
     ALT URI   = https://www.w3.org/Icons/valid-html20-blue
-    Local URI = images/valid_icons/valid-html20
-    Local ALT URI = images/valid_icons/valid-html20-blue
+    Local URI = https://www.w3.org/Icons/valid-html20
+    Local ALT URI = https://www.w3.org/Icons/valid-html20-blue
   </Badge>
 </HTML_2_0>
 
@@ -47,8 +47,8 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html20
     ALT URI   = https://www.w3.org/Icons/valid-html20-blue
-    Local URI = images/valid_icons/valid-html20
-    Local ALT URI = images/valid_icons/valid-html20-blue
+    Local URI = https://www.w3.org/Icons/valid-html20
+    Local ALT URI = https://www.w3.org/Icons/valid-html20-blue
   </Badge>
 </HTML_2_0_Level_2>
 
@@ -65,8 +65,8 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html20
     ALT URI   = https://www.w3.org/Icons/valid-html20-blue
-    Local URI = images/valid_icons/valid-html20
-    Local ALT URI = images/valid_icons/valid-html20-blue
+    Local URI = https://www.w3.org/Icons/valid-html20
+    Local ALT URI = https://www.w3.org/Icons/valid-html20-blue
   </Badge>
 </HTML_2_0_Strict>
 
@@ -83,8 +83,8 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html20
     ALT URI   = https://www.w3.org/Icons/valid-html20-blue
-    Local URI = images/valid_icons/valid-html20
-    Local ALT URI = images/valid_icons/valid-html20-blue
+    Local URI = https://www.w3.org/Icons/valid-html20
+    Local ALT URI = https://www.w3.org/Icons/valid-html20-blue
   </Badge>
 </HTML_2_0_Level_1>
 
@@ -101,8 +101,8 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html20
     ALT URI   = https://www.w3.org/Icons/valid-html20-blue
-    Local URI = images/valid_icons/valid-html20
-    Local ALT URI = images/valid_icons/valid-html20-blue
+    Local URI = https://www.w3.org/Icons/valid-html20
+    Local ALT URI = https://www.w3.org/Icons/valid-html20-blue
   </Badge>
 </HTML_2_0_Strict_Level_1>
 
@@ -122,8 +122,8 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html32
     ALT URI   = https://www.w3.org/Icons/valid-html32-blue
-    Local URI = images/valid_icons/valid-html32
-    Local ALT URI = images/valid_icons/valid-html32-blue
+    Local URI = https://www.w3.org/Icons/valid-html32
+    Local ALT URI = https://www.w3.org/Icons/valid-html32-blue
     Height    = 31
     Width     = 88
   </Badge>
@@ -147,8 +147,8 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html40
     ALT URI   = https://www.w3.org/Icons/valid-html40-blue
-    Local URI = images/valid_icons/valid-html40
-    Local ALT URI = images/valid_icons/valid-html40-blue
+    Local URI = https://www.w3.org/Icons/valid-html40
+    Local ALT URI = https://www.w3.org/Icons/valid-html40-blue
     Height    = 31
     Width     = 88
     Alt       = Valid HTML 4.0 Strict
@@ -169,8 +169,8 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html40
     ALT URI   = https://www.w3.org/Icons/valid-html40-blue
-    Local URI = images/valid_icons/valid-html40
-    Local ALT URI = images/valid_icons/valid-html40-blue
+    Local URI = https://www.w3.org/Icons/valid-html40
+    Local ALT URI = https://www.w3.org/Icons/valid-html40-blue
     Height    = 31
     Width     = 88
     Alt       = Valid HTML 4.0 Transitional
@@ -191,8 +191,8 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html40
     ALT URI   = https://www.w3.org/Icons/valid-html40-blue
-    Local URI = images/valid_icons/valid-html40
-    Local ALT URI = images/valid_icons/valid-html40-blue
+    Local URI = https://www.w3.org/Icons/valid-html40
+    Local ALT URI = https://www.w3.org/Icons/valid-html40-blue
     Height    = 31
     Width     = 88
     Alt       = Valid HTML 4.0 Frameset
@@ -213,8 +213,8 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html401
     ALT URI   = https://www.w3.org/Icons/valid-html401-blue
-    Local URI = images/valid_icons/valid-html401
-    Local ALT URI = images/valid_icons/valid-html401-blue
+    Local URI = https://www.w3.org/Icons/valid-html401
+    Local ALT URI = https://www.w3.org/Icons/valid-html401-blue
     Height    = 31
     Width     = 88
     Alt       = Valid HTML 4.01 Strict
@@ -235,8 +235,8 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html401
     ALT URI   = https://www.w3.org/Icons/valid-html401-blue
-    Local URI = images/valid_icons/valid-html401
-    Local ALT URI = images/valid_icons/valid-html401-blue
+    Local URI = https://www.w3.org/Icons/valid-html401
+    Local ALT URI = https://www.w3.org/Icons/valid-html401-blue
     Height    = 31
     Width     = 88
     Alt       = Valid HTML 4.01 Transitional
@@ -257,8 +257,8 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html401
     ALT URI   = https://www.w3.org/Icons/valid-html401-blue
-    Local URI = images/valid_icons/valid-html401
-    Local ALT URI = images/valid_icons/valid-html401-blue
+    Local URI = https://www.w3.org/Icons/valid-html401
+    Local ALT URI = https://www.w3.org/Icons/valid-html401-blue
     Height    = 31
     Width     = 88
     Alt       = Valid HTML 4.01 Frameset
@@ -279,8 +279,8 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html401
     ALT URI   = https://www.w3.org/Icons/valid-html401-blue
-    Local URI = images/valid_icons/valid-html401
-    Local ALT URI = images/valid_icons/valid-html401-blue
+    Local URI = https://www.w3.org/Icons/valid-html401
+    Local ALT URI = https://www.w3.org/Icons/valid-html401-blue
     Height    = 31
     Width     = 88
     Alt       = Valid HTML 4.01 + RDFa 1.1
@@ -302,8 +302,8 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-html401
     ALT URI   = https://www.w3.org/Icons/valid-html401-blue
-    Local URI = images/valid_icons/valid-html401
-    Local ALT URI = images/valid_icons/valid-html401-blue
+    Local URI = https://www.w3.org/Icons/valid-html401
+    Local ALT URI = https://www.w3.org/Icons/valid-html401-blue
     Height    = 31
     Width     = 88
     Alt       = Valid HTML 4.01 + ARIA 1.0
@@ -341,8 +341,8 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-xhtml10
     ALT URI   = https://www.w3.org/Icons/valid-xhtml10-blue
-    Local URI = images/valid_icons/valid-xhtml10
-    Local ALT URI = images/valid_icons/valid-xhtml10-blue
+    Local URI = https://www.w3.org/Icons/valid-xhtml10
+    Local ALT URI = https://www.w3.org/Icons/valid-xhtml10-blue
     Height    = 31
     Width     = 88
     Alt       = Valid XHTML 1.0 Strict
@@ -366,8 +366,8 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-xhtml10
     ALT URI   = https://www.w3.org/Icons/valid-xhtml10-blue
-    Local URI = images/valid_icons/valid-xhtml10
-    Local ALT URI = images/valid_icons/valid-xhtml10-blue
+    Local URI = https://www.w3.org/Icons/valid-xhtml10
+    Local ALT URI = https://www.w3.org/Icons/valid-xhtml10-blue
     Height    = 31
     Width     = 88
     Alt       = Valid XHTML 1.0 Transitional
@@ -391,8 +391,8 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-xhtml10
     ALT URI   = https://www.w3.org/Icons/valid-xhtml10-blue
-    Local URI = images/valid_icons/valid-xhtml10
-    Local ALT URI = images/valid_icons/valid-xhtml10-blue
+    Local URI = https://www.w3.org/Icons/valid-xhtml10
+    Local ALT URI = https://www.w3.org/Icons/valid-xhtml10-blue
     Height    = 31
     Width     = 88
     Alt       = Valid XHTML 1.0 Frameset
@@ -417,8 +417,8 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-xhtmlbasic10
     ALT URI   = https://www.w3.org/Icons/valid-xhtmlbasic10-blue
-    Local URI = images/valid_icons/valid-xhtmlbasic10
-    Local ALT URI = images/valid_icons/valid-xhtmlbasic10-blue
+    Local URI = https://www.w3.org/Icons/valid-xhtmlbasic10
+    Local ALT URI = https://www.w3.org/Icons/valid-xhtmlbasic10-blue
     Height    = 31
     Width     = 88
     Alt       = Valid XHTML Basic 1.0
@@ -509,8 +509,8 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-xhtmlprint10
     ALT URI   = https://www.w3.org/Icons/valid-xhtmlprint10-blue
-    Local URI = images/valid_icons/valid-xhtmlprint10
-    Local ALT URI = images/valid_icons/valid-xhtmlprint10-blue
+    Local URI = https://www.w3.org/Icons/valid-xhtmlprint10
+    Local ALT URI = https://www.w3.org/Icons/valid-xhtmlprint10-blue
     Height    = 31
     Width     = 88
     Alt       = Valid XHTML-Print 1.0
@@ -534,8 +534,8 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-xhtml11
     ALT URI   = https://www.w3.org/Icons/valid-xhtml11-blue
-    Local URI = images/valid_icons/valid-xhtml11
-    Local ALT URI = images/valid_icons/valid-xhtml11-blue
+    Local URI = https://www.w3.org/Icons/valid-xhtml11
+    Local ALT URI = https://www.w3.org/Icons/valid-xhtml11-blue
     Height    = 31
     Width     = 88
     Alt       = Valid XHTML 1.1
@@ -608,8 +608,8 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-mathml20
     ALT URI   = https://www.w3.org/Icons/valid-mathml20-blue
-    Local URI = images/valid_icons/valid-mathml20
-    Local ALT URI = images/valid_icons/valid-mathml20-blue
+    Local URI = https://www.w3.org/Icons/valid-mathml20
+    Local ALT URI = https://www.w3.org/Icons/valid-mathml20-blue
     Height    = 31
     Width     = 88
     Alt       = Valid MathML 2.0
@@ -681,8 +681,8 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-xhtml-rdfa
     ALT URI   = https://www.w3.org/Icons/valid-xhtml-rdfa-blue
-    Local URI = images/valid_icons/valid-xhtml-rdfa
-    Local ALT URI = images/valid_icons/valid-xhtml-rdfa-blue
+    Local URI = https://www.w3.org/Icons/valid-xhtml-rdfa
+    Local ALT URI = https://www.w3.org/Icons/valid-xhtml-rdfa-blue
     Height    = 31
     Width     = 88
     Alt       = Valid XHTML + RDFa
@@ -706,8 +706,8 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-xhtml11
     ALT URI   = https://www.w3.org/Icons/valid-xhtml11-blue
-    Local URI = images/valid_icons/valid-xhtml11
-    Local ALT URI = images/valid_icons/valid-xhtml11-blue
+    Local URI = https://www.w3.org/Icons/valid-xhtml11
+    Local ALT URI = https://www.w3.org/Icons/valid-xhtml11-blue
     Height    = 31
     Width     = 88
     Alt       = Valid XHTML + ARIA 1.0
@@ -735,8 +735,8 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-svg10
     ALT URI   = https://www.w3.org/Icons/valid-svg10-blue
-    Local URI = images/valid_icons/valid-svg10
-    Local ALT URI = images/valid_icons/valid-svg10-blue
+    Local URI = https://www.w3.org/Icons/valid-svg10
+    Local ALT URI = https://www.w3.org/Icons/valid-svg10-blue
     Height    = 31
     Width     = 88
     Alt       = Valid SVG 1.0
@@ -760,8 +760,8 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-svg11
     ALT URI   = https://www.w3.org/Icons/valid-svg11-blue
-    Local URI = images/valid_icons/valid-svg11
-    Local ALT URI = images/valid_icons/valid-svg11-blue
+    Local URI = https://www.w3.org/Icons/valid-svg11
+    Local ALT URI = https://www.w3.org/Icons/valid-svg11-blue
     Height    = 31
     Width     = 88
     Alt       = Valid SVG 1.1
@@ -787,8 +787,8 @@
   <Badge>
     URI       = https://www.w3.org/Icons/valid-svgtiny11
     ALT URI   = https://www.w3.org/Icons/valid-svgtiny11-blue
-    Local URI = images/valid_icons/valid-svgtiny11
-    Local ALT URI = images/valid_icons/valid-svgtiny11-blue
+    Local URI = https://www.w3.org/Icons/valid-svgtiny11
+    Local ALT URI = https://www.w3.org/Icons/valid-svgtiny11-blue
     Height    = 31
     Width     = 88
     Alt       = Valid SVG 1.1 Tiny

--- a/httpd/cgi-bin/check
+++ b/httpd/cgi-bin/check
@@ -1694,9 +1694,7 @@ sub report_valid
         if (exists $CFG->{Types}->{$File->{DOCTYPE}}->{Badge}) {
             my $cfg = $CFG->{Types}->{$File->{DOCTYPE}};
             $T->param(badge_uri           => $cfg->{Badge}->{URI});
-            $T->param(local_badge_uri     => $cfg->{Badge}->{'Local URI'});
             $T->param(badge_alt_uri       => $cfg->{Badge}->{'Alt URI'});
-            $T->param(local_alt_badge_uri => $cfg->{Badge}->{'Local ALT URI'});
             $T->param(badge_alt           => $cfg->{Badge}->{Alt});
             $T->param(badge_rdfa          => $cfg->{Badge}->{RDFa});
             $T->param(badge_h             => $cfg->{Badge}->{Height});

--- a/share/templates/en_US/valid.tmpl
+++ b/share/templates/en_US/valid.tmpl
@@ -66,7 +66,7 @@
     to your Web page:
   </p>
   <img
-    class="inline-badge" src="<TMPL_IF NAME="local_badge_uri"><TMPL_VAR NAME="local_badge_uri" ESCAPE="HTML"><TMPL_ELSE><TMPL_VAR NAME="badge_uri" ESCAPE="HTML"></TMPL_IF>"
+    class="inline-badge" src="<TMPL_VAR NAME="badge_uri" ESCAPE="HTML">"
     alt="<TMPL_VAR NAME="badge_alt" ESCAPE="HTML">"
     <TMPL_IF NAME="badge_h">height="<TMPL_VAR NAME="badge_h">"</TMPL_IF>
     <TMPL_IF NAME="badge_w">width="<TMPL_VAR NAME="badge_w">"</TMPL_IF>
@@ -81,7 +81,7 @@
   </pre>
   <TMPL_IF NAME="badge_alt_uri">
   <img
-    class="inline-badge" src="<TMPL_IF NAME="local_alt_badge_uri"><TMPL_VAR NAME="local_alt_badge_uri" ESCAPE="HTML"><TMPL_ELSE><TMPL_VAR NAME="badge_alt_uri" ESCAPE="HTML"></TMPL_IF>"
+    class="inline-badge" src="<TMPL_VAR NAME="badge_alt_uri" ESCAPE="HTML">"
     alt="<TMPL_VAR NAME="badge_alt" ESCAPE="HTML">"
     <TMPL_IF NAME="badge_h">height="<TMPL_VAR NAME="badge_h">"</TMPL_IF>
     <TMPL_IF NAME="badge_w">width="<TMPL_VAR NAME="badge_w">"</TMPL_IF>


### PR DESCRIPTION
Goal is to serve those valid icons from a single central location (https://www.w3.org/Icons/) instead of having multiple copies. I will take care of deleting files from `htdocs/images/valid_icons/` in a separate pull request once we'll have the redirects in place.