### PR TITLE
fix: handle incorrect “markup” path in URI processing [to fix validator links]

### DIFF
--- a/httpd/cgi-bin/check
+++ b/httpd/cgi-bin/check
@@ -3372,6 +3372,8 @@ sub self_url_file
     my $File = shift;
 
     my $thispage    = $File->{Env}->{'Self URI'};
+    # Remove any “markup” path component that might have been added by proxy/rewrite rules
+    $thispage =~ s|/markup(?=/check)|/|;
     my $escaped_uri = uri_escape($File->{URI});
     $thispage .= qq(?uri=$escaped_uri);
     $thispage .= ';ss=1' if $File->{Opt}->{'Show Source'};


### PR DESCRIPTION
> Adjusts URI manipulation to remove unwanted "markup" components added by proxy/rewrite rules. Ensures correct behavior in URL handling to prevent potential routing issues.

Best-guess fix for issue [wrong-page issue](https://lists.w3.org/Archives/Public/www-validator/2025Jun/0001.html) reported by Anton Shepelev.